### PR TITLE
Fix case sensitivity in git repository validation

### DIFF
--- a/src/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
+++ b/src/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
@@ -92,7 +92,7 @@ public sealed class RepositoryWrapper : IDisposable
         }
 
         var normalizedRootFolderPath = rootFolder.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        if (output.TrimEnd('\n') != normalizedRootFolderPath)
+        if (!output.TrimEnd('\n').Equals(normalizedRootFolderPath, StringComparison.OrdinalIgnoreCase))
         {
             _log.Error($"Not a valid git repository root path: {rootFolder}");
             throw new ArgumentException($"Not a valid git repository root path: {rootFolder}");


### PR DESCRIPTION
The git validation root repository compare was not case-insensitive, while the Windows filesystem is case-insensitive. This fixes an issue where the drive letter, among other things, might not match the case of the provided path, causing a valid git repository to marked as invalid.