### PR TITLE
Add GPO support for WindowsAdvancedSettings

### DIFF
--- a/src/Common/Helpers/GPOHelper.cs
+++ b/src/Common/Helpers/GPOHelper.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Win32;
+using Serilog;
+
+namespace WindowsAdvancedSettings.Common.Helpers;
+
+public class GPOHelper
+{
+    private static readonly ILogger _log = Log.ForContext("SourceContext", nameof(GPOHelper));
+
+    private enum GpoRuleConfigured
+    {
+        WrongValue = -3, // The policy is set to an unrecognized value
+        Unavailable = -2, // Couldn't access registry
+        NotConfigured = -1, // Policy is not configured
+        Disabled = 0, // Policy is disabled
+        Enabled = 1, // Policy is enabled
+    }
+
+    // Registry path where gpo policy values are stored
+    private const string PoliciesScopeMachine = "HKEY_LOCAL_MACHINE";
+    private const string PoliciesPath = @"\SOFTWARE\Policies\Microsoft\Windows\WindowsAdvancedSettings";
+
+    // Registry value names
+    private const string PolicyConfigureEnabledWindowsAdvancedSettings = "ConfigureEnabledWindowsAdvancedSettings";
+
+    private static GpoRuleConfigured GetConfiguredValue(string registryValueName)
+    {
+        try
+        {
+            var rawValue = Registry.GetValue(
+                keyName: PoliciesScopeMachine + PoliciesPath,
+                valueName: registryValueName,
+                defaultValue: GpoRuleConfigured.NotConfigured);
+
+            _log.Debug($"Registry value {registryValueName} set to {rawValue}");
+
+            // Value will be null if the subkey specified by keyName does not exist.
+            if (rawValue == null)
+            {
+                return GpoRuleConfigured.NotConfigured;
+            }
+            else if (rawValue is not int && rawValue is not GpoRuleConfigured)
+            {
+                return GpoRuleConfigured.WrongValue;
+            }
+            else
+            {
+                return (GpoRuleConfigured)rawValue;
+            }
+        }
+        catch (System.Security.SecurityException)
+        {
+            // The user does not have the permissions required to read from the registry key.
+            return GpoRuleConfigured.Unavailable;
+        }
+        catch (System.IO.IOException)
+        {
+            // The RegistryKey that contains the specified value has been marked for deletion.
+            return GpoRuleConfigured.Unavailable;
+        }
+        catch (System.ArgumentException)
+        {
+            // keyName does not begin with a valid registry root.
+            return GpoRuleConfigured.NotConfigured;
+        }
+    }
+
+    private static bool EvaluateConfiguredValue(string registryValueName, GpoRuleConfigured defaultValue)
+    {
+        var configuredValue = GetConfiguredValue(registryValueName);
+        if (configuredValue < 0)
+        {
+            if (configuredValue != GpoRuleConfigured.NotConfigured)
+            {
+                // Only log an error if a configuration was attempted but was incorrect. NotConfigured is expected state.
+                _log.Error($"Registry value {registryValueName} set to {configuredValue}, using default {defaultValue} instead.");
+            }
+
+            configuredValue = defaultValue;
+        }
+
+        return configuredValue == GpoRuleConfigured.Enabled;
+    }
+
+    public static bool GetConfiguredEnabledWindowsAdvancedSettingsValue()
+    {
+        var defaultValue = GpoRuleConfigured.Enabled;
+        return EvaluateConfiguredValue(PolicyConfigureEnabledWindowsAdvancedSettings, defaultValue);
+    }
+}

--- a/src/Common/WindowsAdvancedSettings.admx
+++ b/src/Common/WindowsAdvancedSettings.admx
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="0.1900" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+  <policyNamespaces>
+    <target prefix="devhome" namespace="Microsoft.Policies.DevHome" />
+  </policyNamespaces>
+  <resources minRequiredRevision="0.1900"/>
+  <supportedOn>
+    <definitions>
+      <definition name="SUPPORTED_DEVHOME_0_1900" displayName="$(string.SUPPORTED_DEVHOME_0_1900)"/>
+    </definitions>
+  </supportedOn>
+  <categories>
+    <category name="DevHome" displayName="$(string.DevHome)" />
+  </categories>
+
+  <policies>
+
+ <!--The name (id) of the policy is different from the valueName to sort it as first policy in edit dialog. The order is sorted alphabetically based on the "name" property.-->
+    <policy name="ConfigureAllDevHomeEnabledState" class="Both" displayName="$(string.ConfigureAllDevHomeEnabledState)" explainText="$(string.ConfigureAllDevHomeEnabledStateDescription)" key="Software\Policies\DevHome" valueName="ConfigureEnabledDevHome">
+      <parentCategory ref="DevHome" />
+      <supportedOn ref="SUPPORTED_DEVHOME_0_1901" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+  </policies>
+</policyDefinitions>

--- a/src/Common/gpo/assets/WindowsAdvancedSettings.admx
+++ b/src/Common/gpo/assets/WindowsAdvancedSettings.admx
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="0.1900" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+  <policyNamespaces>
+    <target prefix="windowsadvancedsettings" namespace="Microsoft.Policies.WindowsAdvancedSettings" />
+  </policyNamespaces>
+  <resources minRequiredRevision="0.1900"/>
+  <supportedOn>
+    <definitions>
+      <definition name="SUPPORTED_WINDOWSADVANCEDSETTINGS_0_1900" displayName="$(string.SUPPORTED_WINDOWSADVANCEDSETTINGS_0_1900)"/>
+    </definitions>
+  </supportedOn>
+  <categories>
+    <category name="WindowsAdvancedSettings" displayName="$(string.WindowsAdvancedSettings)" />
+  </categories>
+
+  <policies>
+
+ <!--The name (id) of the policy is different from the valueName to sort it as first policy in edit dialog. The order is sorted alphabetically based on the "name" property.-->
+    <policy name="ConfigureAllWindowsAdvancedSettingsEnabledState" class="Both" displayName="$(string.ConfigureAllWindowsAdvancedSettingsEnabledState)" explainText="$(string.ConfigureAllWindowsAdvancedSettingsEnabledStateDescription)" key="Software\Policies\Microsoft\Windows\WindowsAdvancedSettings" valueName="ConfigureEnabledWindowsAdvancedSettings">
+      <parentCategory ref="DevHome" />
+      <supportedOn ref="SUPPORTED_WINDOWSADVANCEDSETTINGS_0_1900" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+  </policies>
+</policyDefinitions>

--- a/src/Common/gpo/assets/en-US/WindowsAdvancedSettings.adml
+++ b/src/Common/gpo/assets/en-US/WindowsAdvancedSettings.adml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="0.1900" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+  <displayName>Windows Advanced Settings</displayName>
+  <description>Windows Advanced Settings</description>
+  <resources>
+    <stringTable>
+      <string id="WindowsAdvancedSettings">Microsoft Windows Advanced Settings</string>
+
+      <string id="SUPPORTED_WINDOWSADVANCEDSETTINGS_0_1900">Windows Advanced Settings version 0.1900.* or later</string>
+
+      <string id="ConfigureAllWindowsAdvancedSettingsEnabledStateDescription">
+        This policy configures the enabled state for Windows Advanced Settings.
+
+        If you enable this setting, Windows Advanced Settings will be always enabled and the user won't be able to disable it.
+
+        If you disable this setting, Windows Advanced Settings will be always disabled and the user won't be able to enable it.
+
+        If you don't configure this setting, users are able to enable or disable Windows Advanced Settings.
+
+        This policy will override any enabled state policies for individual Windows Advanced Settings features.
+      </string>
+
+      <string id="ConfigureAllWindowsAdvancedSettingsEnabledState">Configure Windows Advanced Settings enabled state</string>
+    </stringTable>
+
+  </resources>
+</policyDefinitionResources>
+

--- a/src/FileExplorerGitIntegration/Program.cs
+++ b/src/FileExplorerGitIntegration/Program.cs
@@ -76,6 +76,13 @@ public sealed class Program
 
     private static void HandleCOMServerActivation()
     {
+        var gpoPolicyEnabled = GPOHelper.GetConfiguredEnabledWindowsAdvancedSettingsValue();
+        if (!gpoPolicyEnabled)
+        {
+            Log.Information($"Windows Advanced Settings is disabled by policy, exiting.");
+            return;
+        }
+
         Log.Information($"Activating COM Server");
 
         RepositoryCache cache = new RepositoryCache();

--- a/src/FileExplorerSourceControlIntegration/Program.cs
+++ b/src/FileExplorerSourceControlIntegration/Program.cs
@@ -55,7 +55,8 @@ public sealed class Program
         var gpoPolicyEnabled = GPOHelper.GetConfiguredEnabledWindowsAdvancedSettingsValue();
         if (!gpoPolicyEnabled)
         {
-            Log.Information($"Windows Advanced Settings is disabled by policy, exiting.");
+            Log.Information($"Windows Advanced Settings is disabled by policy, removing all registered entries for this provider and exiting.");
+            ConfigureFolderPath.RemoveAllForCurrentProvider();
             return;
         }
 

--- a/src/FileExplorerSourceControlIntegration/Program.cs
+++ b/src/FileExplorerSourceControlIntegration/Program.cs
@@ -52,6 +52,13 @@ public sealed class Program
 
     private static void HandleCOMServerActivation()
     {
+        var gpoPolicyEnabled = GPOHelper.GetConfiguredEnabledWindowsAdvancedSettingsValue();
+        if (!gpoPolicyEnabled)
+        {
+            Log.Information($"Windows Advanced Settings is disabled by policy, exiting.");
+            return;
+        }
+
         Log.Information($"Activating COM Server");
         using var sourceControlProviderServer = new SourceControlProviderServer();
         var sourceControlProviderInstance = new SourceControlProvider();

--- a/test/AdvancedSettings.Tester/Program.cs
+++ b/test/AdvancedSettings.Tester/Program.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AdvancedSettings.Tester;
+using FileExplorerSourceControlIntegration;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Internal.Windows.DevHome.Helpers.FileExplorer;
+using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Storage;
 
@@ -21,17 +23,24 @@ internal sealed class Program
 
         if (args.Length == 0)
         {
-            ConfigureFolderPath.DisplayStatus();
+            DisplayStatus();
         }
         else if (args.Length > 2 && args[0].Equals("add", StringComparison.OrdinalIgnoreCase))
         {
+            Console.WriteLine($"Registering source folder: {args[1]} for provider {args[2]}");
             ConfigureFolderPath.AddPath(args[1], args[2]);
-            ConfigureFolderPath.DisplayStatus();
+            DisplayStatus();
         }
         else if (args.Length > 1 && args[0].Equals("remove", StringComparison.OrdinalIgnoreCase))
         {
+            Console.WriteLine($"Removing path {args[1]}");
             ConfigureFolderPath.RemovePath(args[1]);
-            ConfigureFolderPath.DisplayStatus();
+            DisplayStatus();
+        }
+        else if (args.Length > 1 && args[0].Equals("removeall", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine($"Removing all folders for provider: {args[1]}");
+            ConfigureFolderPath.RemoveAllForProvider(args[1]);
         }
         else
         {
@@ -39,6 +48,31 @@ internal sealed class Program
         }
 
         Log.CloseAndFlush();
+    }
+
+    private static void DisplayStatus()
+    {
+        foreach (var folderInfo in ExtraFolderPropertiesWrapper.GetRegisteredFolderInfos())
+        {
+            var providerName = GetProviderName(folderInfo.HandlerClsid);
+            Console.WriteLine($"{providerName}: {folderInfo.RootFolderPath}  {{{folderInfo.HandlerClsid}}}  {folderInfo.AppId}");
+        }
+    }
+
+    private static string GetProviderName(Guid guid)
+    {
+        if (guid.Equals(ConfigureFolderPath.DevProvider))
+        {
+            return "DEV";
+        }
+        else if (guid.Equals(ConfigureFolderPath.ReleaseProvider))
+        {
+            return "REL";
+        }
+        else
+        {
+            return "UNK";
+        }
     }
 
     private static void DisplayHelp()


### PR DESCRIPTION
Adds in GPO support ported over from Dev Home.

**Notable changes**
* Path of the policy regkey was updated to be HKLM\Software\Policies\Microsoft\Windows\WindowsAdvancedSettings to be consistent with other Windows policies.
* Logging changed to be a bit less noisy on the happy path of NotConfigured (shows nothing) and will only show errors if an invalid configuration was supplied.
* Folder configuration moved to the SourceControlIntegration project.
* Added support to remove all registered folders for a provider.
* If Advanced Settings is disabled by GPO and is launched, it will also remove all registered folders for Advanced Settings so File Explorer will not try to restart it.
* Added support for removing all registered folders for a provider to the tester app. 

Policy was added to the COM server launches, but not the main app since Settings uses that for configuration data, I did not want to break Settings. 

The COM servers for source control integration will not launch if the policy is disabled.


**Tested**
* Verified setting the policy prevents COM servers from activating.

It is notable that I observed File Explorer will attempt to restart the COM servers every 30 seconds, but this only happens once since the folder path is de-registered when GPO is disabled. Explorer will launch the COM server one additional time, it will exit, and then not be re-attempted.